### PR TITLE
Fixed: force option

### DIFF
--- a/mondo
+++ b/mondo
@@ -43,7 +43,9 @@ main(){
       v | version ) printinfo version ; exit ;;
       h | help ) printinfo "${2:-}" shift 2 ; exit ;;
 
-      f | force    ) __force=1 shift ;;  
+      f | force    )
+                     __force=1
+                     shift ;;  
 
       n | new      ) 
                      __action=new
@@ -257,7 +259,7 @@ newbase(){
 }
 
 newtheme(){
-  [[ -f "$MONDO_DIR/themes/$1" ]] && ((__force!=1)) \
+  [[ -f "$MONDO_DIR/themes/$1" ]] && (($__force!=1)) \
     && ERX "theme $1 already exist"
 
   [[ -f "$MONDO_DIR/themes/_default" ]] \
@@ -303,7 +305,7 @@ themetogenerator(){
   [[ -d "$dir" ]] \
     || ERX "generator $this_generator doen't exist."
 
-  if [[ -f "$dir/$__wt_name" ]] && ((__force!=1)); then
+  if [[ -f "$dir/$__wt_name" ]] && (($__force!=1)); then
     [[ $__action = generate ]] \
       && ERR "theme $__wt_name is already in $this_generator."
     :


### PR DESCRIPTION
The force `-f` option was not working with either the theme generation option `-g` nor the generator updating option `-u`. There were 2 reasons:

1) The condition `((__force!=1))` on lines 260 and 306 were missing `$` in front of the `__force`. So the value of the variable `__force` was not being compared, meaning whether or not `-f` was specified, `ERX` or `ERR` would always be called and the theme files would not be updated.

2) The value of global variable `__force` was never being changed, despite an assignment in the case statement on line 46. After a long ass time wondering why, I found out that having the assignment `__force=1` on the same line as the expression, for some reason, doesn't change the value of `__force`.

After fixing these issues, the force option works with both `-g` and `-u`!